### PR TITLE
Fixed cast bug in MySqlConnectionImpl.prepare

### DIFF
--- a/packages/sqljocky5/CHANGELOG.md
+++ b/packages/sqljocky5/CHANGELOG.md
@@ -11,3 +11,7 @@
 ## 3.0.0
 
 - migrated to null security and dependency updates
+
+## 3.0.1
+
+- Fixed cast bug in MySqlConnectionImpl.prepare.

--- a/packages/sqljocky5/lib/internal/connection/impl.dart
+++ b/packages/sqljocky5/lib/internal/connection/impl.dart
@@ -69,7 +69,7 @@ class MySqlConnectionImpl implements MySqlConnection {
 
   @override
   Future<Prepared> prepare(String sql) async {
-    PreparedQuery query = await (_socket.execHandler(PrepareHandler(sql), _timeout) as FutureOr<PreparedQuery>);
+    final query = await _socket.execHandler(PrepareHandler(sql), _timeout);
     return PreparedImpl._(this, query);
   }
 

--- a/packages/sqljocky5/pubspec.yaml
+++ b/packages/sqljocky5/pubspec.yaml
@@ -1,5 +1,5 @@
 name: galileo_sqljocky5
-version: 3.0.0
+version: 3.0.1
 description: MySQL driver for Dart with support for prepared statements, transactions and connection pooling.
 documentation:
 homepage: https://github.com/insinfo/galileo


### PR DESCRIPTION
This is a pull request to fix a bug in the `prepare` method in `MySqlConnectionImpl`.

**Problem**

Preparing a SQL statement always raising a cast exception.

**Cause**

The problem is cased by the `as` in this method:

https://github.com/insinfo/galileo/blob/0771dd93e012f6e75098d0527ee271907374b368/packages/sqljocky5/lib/internal/connection/impl.dart#L70-L74

Since `_socket.execHandler` returns a `Future<dynamic>`, attempting to treat it as a `FutureOr<PreparedQuery>` will **always** cause a runtime cast exception. Treating it as a `Future<PreparedQuery>` would also always cause a cast exception.

Until the Future produces a value it cannot be casted, because the actual type of the _dynamic_ is not yet known.

**Solution**

The fix is to simply remove the unnecessary cast.

```dart
final query = await _socket.execHandler(PrepareHandler(sql), _timeout);
```

In my testing, the value produced by the _await_ is a `PreparedQuery`. I don't know whether it could be anything else. If it can, then maybe adding a cast is useful for detecting errors. But even that is not necessary, since it will be implicitly treated as a _PreparedQuery_ when it is passed as a parameter to the `PreparedImpl._` constructor in the next line. If it can't, then a runtime exception will be raised.
